### PR TITLE
Removed the frame options

### DIFF
--- a/app/slacky.js
+++ b/app/slacky.js
@@ -29,10 +29,6 @@ function createWindow(destUrl) {
 			innerBounds: {
 				minWidth: width,
 				minHeight: height
-			},
-			// Set the frame color so it doesn't just look like a browser frame
-			frame: {
-				color: frameColor
 			}
 		}, function(createdWindow) {
 			createdWindow.contentWindow.onload = function() {


### PR DESCRIPTION
When you specify frame options like 'color' the window doesn't inherit the OS' theme in regards to window controls, colours, etc. This is a personal preference but I get frustrated with 'close', 'minimise', and 'maximise' suddenly appearing on the other side of the window and not looking like the rest of my native apps. I'm assuming this issue is more noticeable on certain Linux flavours and windows managers, and Mac OS.

I'm mostly putting this here so other people who enjoy your simple but awesome webview app for Slack can also enjoy native windows decorations on their chosen OS.
