### PR TITLE
Open links in a new, regular Chrome window or tab

### DIFF
--- a/app/slacky.js
+++ b/app/slacky.js
@@ -50,13 +50,10 @@ function createWindow(destUrl) {
 }
 
 function windowEventHandlers(webview, _blank) {
-	webview.addEventListener('newwindow', function(dest) {
-		// Event handler for when external links are clicked because for some
-		// reason window.open(dest.targetUrl) just crashes the chrome tab
-		dest.preventDefault();
-		if(_blank)
-			createWindow(dest.targetUrl);
-		else
-			webview.src = dest.targetUrl;
+	webview.addEventListener('newwindow', function(event) {
+		// Event handler for when external links are clicked because of
+		// the Chrome packaged app security restriction on opening links in the regular browser
+		event.preventDefault();
+		window.open(event.targetUrl);
 	});
 }


### PR DESCRIPTION
The old way the code was handling links opened them in a webapp webview window. The reasoning behind it - as I understand it from the code comments - was because window.open() crashed Chrome. But that's only correct when trying to use window.open() without the event handler because of a security restriction on Chrome packaged apps. Once you add the event handler, window.open() works perfectly fine.

See more information here - http://stackoverflow.com/a/18452171
