### PR TITLE
Open link in new window correctly.

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Slacky",
   "author": "SociallyTied",
-  "version": "1.5",
+  "version": "1.6",
   "minimum_chrome_version": "23",
   "description": "Simple Slack app for Chrome I created because I hate having it open in another tab :)",
   "icons": {

--- a/app/slacky.js
+++ b/app/slacky.js
@@ -48,37 +48,36 @@ function createWindow(destUrl) {
                     };
                 });
                 webview.addEventListener('newwindow', function(event) {
-                        // Event handler for when external links are clicked because of
-                        // the Chrome packaged app security restriction on opening links in the regular browser
-                        event.preventDefault();
-												var url = event.targetUrl;
-                        chrome.app.window.create(
-                            view, {
-                                hidden: true,
-																innerBounds: {
-																	width:1024,
-																	height: 768
-																}
-                            }, // only show window when webview is configured
-                            function(appWin) {
-                                appWin.contentWindow.addEventListener('DOMContentLoaded',
-                                    function(e) {
-                                        // when window is loaded, set webview source
-                                        var webview = appWin.contentWindow.document.querySelector('webview');
-																				appWin.onBoundsChanged.addListener(function() {
-												                    var bounds = appWin.getBounds();
-												                    webview.style.height = bounds.height;
-												                    webview.style.width = bounds.width;
-												                });
-                                        webview.src = url;
-                                        // now we can show it:
-                                        appWin.show();
-                                    }
-                                );
-                            });
-                    }
-                );
-        };
-    }
-);
+                    // Event handler for when external links are clicked because of
+                    // the Chrome packaged app security restriction on opening links in the regular browser
+                    event.preventDefault();
+                    var url = event.targetUrl;
+                    chrome.app.window.create(
+                        view, {
+                            hidden: true,
+                            innerBounds: {
+                                width: 1024,
+                                height: 768
+                            }
+                        }, // only show window when webview is configured
+                        function(appWin) {
+                            appWin.contentWindow.addEventListener('DOMContentLoaded',
+                                function(e) {
+                                    // when window is loaded, set webview source
+                                    var webview = appWin.contentWindow.document.querySelector('webview');
+                                    appWin.onBoundsChanged.addListener(function() {
+                                        var bounds = appWin.getBounds();
+                                        webview.style.height = bounds.height;
+                                        webview.style.width = bounds.width;
+                                    });
+                                    webview.src = url;
+                                    // now we can show it:
+                                    appWin.show();
+                                }
+                            );
+                        });
+                });
+            };
+        }
+    );
 }

--- a/app/slacky.js
+++ b/app/slacky.js
@@ -6,53 +6,79 @@ var height = 700;
 
 // Setup the initial Slack window
 chrome.app.runtime.onLaunched.addListener(function() {
-	createWindow(baseUrl);
+    createWindow(baseUrl);
 });
 
 function createWindow(destUrl) {
-	chrome.app.window.create(
-		view, {
-			// Set the height and width and then rander it in the middle of the screen
-			bounds: {
-				width: width,
-				height: height,
-				left: Math.round((screen.availWidth - width) / 2),
-				top: Math.round((screen.availHeight - height) / 2)
-			},
-			// Minimum sizes
-			innerBounds: {
-				minWidth: width,
-				minHeight: height
-			}
-		}, function(createdWindow) {
-			createdWindow.contentWindow.onload = function() {
-				// Retrieve the webview element
-				var webview = createdWindow.contentWindow.document.querySelector('webview');
-				// When the window is resized, resize the webview to conform to the new size
-				createdWindow.onBoundsChanged.addListener(function() {
-					var bounds = createdWindow.getBounds();
-					webview.style.height = bounds.height;
-					webview.style.width = bounds.width;
-				});
-				// Render the page requested inside the webview
-				webview.src = destUrl;
-				// Add event listener for when webview finishes loading
-				webview.addEventListener("contentload", function() {
-					// Focus on the webview, so focus can go to the proper elements within it
-					webview.focus();
-					// Add event listener for when window becomes focused
-					createdWindow.contentWindow.onfocus = function() {
-						// Focus on the webview, so focus can go to the proper elements within it
-						webview.focus();
-					};
-				});
-				webview.addEventListener('newwindow', function(event) {
-					// Event handler for when external links are clicked because of
-					// the Chrome packaged app security restriction on opening links in the regular browser
-					event.preventDefault();
-					window.open(event.targetUrl);
-				});
-			};
-		}
-	);
+    chrome.app.window.create(
+        view, {
+            // Set the height and width and then rander it in the middle of the screen
+            bounds: {
+                width: width,
+                height: height,
+                left: Math.round((screen.availWidth - width) / 2),
+                top: Math.round((screen.availHeight - height) / 2)
+            },
+            // Minimum sizes
+            innerBounds: {
+                minWidth: width,
+                minHeight: height
+            }
+        },
+        function(createdWindow) {
+            createdWindow.contentWindow.onload = function() {
+                // Retrieve the webview element
+                var webview = createdWindow.contentWindow.document.querySelector('webview');
+                // When the window is resized, resize the webview to conform to the new size
+                createdWindow.onBoundsChanged.addListener(function() {
+                    var bounds = createdWindow.getBounds();
+                    webview.style.height = bounds.height;
+                    webview.style.width = bounds.width;
+                });
+                // Render the page requested inside the webview
+                webview.src = destUrl;
+                // Add event listener for when webview finishes loading
+                webview.addEventListener("contentload", function() {
+                    // Focus on the webview, so focus can go to the proper elements within it
+                    webview.focus();
+                    // Add event listener for when window becomes focused
+                    createdWindow.contentWindow.onfocus = function() {
+                        // Focus on the webview, so focus can go to the proper elements within it
+                        webview.focus();
+                    };
+                });
+                webview.addEventListener('newwindow', function(event) {
+                        // Event handler for when external links are clicked because of
+                        // the Chrome packaged app security restriction on opening links in the regular browser
+                        event.preventDefault();
+												var url = event.targetUrl;
+                        chrome.app.window.create(
+                            view, {
+                                hidden: true,
+																innerBounds: {
+																	width:1024,
+																	height: 768
+																}
+                            }, // only show window when webview is configured
+                            function(appWin) {
+                                appWin.contentWindow.addEventListener('DOMContentLoaded',
+                                    function(e) {
+                                        // when window is loaded, set webview source
+                                        var webview = appWin.contentWindow.document.querySelector('webview');
+																				appWin.onBoundsChanged.addListener(function() {
+												                    var bounds = appWin.getBounds();
+												                    webview.style.height = bounds.height;
+												                    webview.style.width = bounds.width;
+												                });
+                                        webview.src = url;
+                                        // now we can show it:
+                                        appWin.show();
+                                    }
+                                );
+                            });
+                    }
+                );
+        };
+    }
+);
 }


### PR DESCRIPTION
This fixes the problem where clicking an external link in slacky causes a tab to open in chrome with an "Oh Snap" error message. The external link will now open in a new window owned by the slacky "app".