### PR TITLE
Feature/smaller window

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Slacky",
   "author": "SociallyTied",
-  "version": "1.6",
+  "version": "1.7",
   "minimum_chrome_version": "23",
   "description": "Simple Slack app for Chrome I created because I hate having it open in another tab :)",
   "icons": {

--- a/app/slacky.js
+++ b/app/slacky.js
@@ -3,6 +3,8 @@ var baseUrl = "https://my.slack.com";
 var view = "view.html";
 var width = 1100;
 var height = 700;
+var minWidth = 765;
+var minHeight = 300;
 
 // Setup the initial Slack window
 chrome.app.runtime.onLaunched.addListener(function() {
@@ -12,17 +14,14 @@ chrome.app.runtime.onLaunched.addListener(function() {
 function createWindow(destUrl) {
     chrome.app.window.create(
         view, {
-            // Set the height and width and then rander it in the middle of the screen
-            bounds: {
+            // Set the height and width and then render it in the middle of the screen
+            innerBounds: {
                 width: width,
                 height: height,
+                minWidth: minWidth,
+                minHeight: minHeight,
                 left: Math.round((screen.availWidth - width) / 2),
                 top: Math.round((screen.availHeight - height) / 2)
-            },
-            // Minimum sizes
-            innerBounds: {
-                minWidth: width,
-                minHeight: height
             }
         }, function(createdWindow) {
             createdWindow.contentWindow.onload = function() {


### PR DESCRIPTION
Fix for #6 - The min width of the app is now the actual min width of the content within the container. I hope the new size is more reasonable, because I'm not able to make it any smaller without the scrollbar being cut off (unless I start overriding Slack's styles, which would be gross).
